### PR TITLE
Fix publish workflow: enable tests on release

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -8,6 +8,8 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  release:
+    types: [published]
 
 env:
   TEST_DB_PASSWORD: example

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -7,7 +7,7 @@ networks:
 
 services:
   rail-bot:
-    image: train-butler-01
+    image: corwinpro/train-butler
     restart: always
     environment:
       DB_USER: ${DB_USER}


### PR DESCRIPTION
Contributes to #2 

I forgot about a dependent workflow (test) on release. Docker image publish depends on it as it waits for it to complete