### PR TITLE
Yet another fix to publish workflow

### DIFF
--- a/.github/workflows/image-publish.yml
+++ b/.github/workflows/image-publish.yml
@@ -13,7 +13,7 @@ jobs:
         uses: lewagon/wait-on-check-action@v1.0.0
         with:
           ref: ${{ github.ref }}
-          check-name: "Run unittest"
+          check-name: "Run test"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 10
       - name: Check out the repo

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -16,13 +16,12 @@ env:
   TEST_DB_NAME: test_db
 
 jobs:
-  build:
-
+  test:
+    name: Run test
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: [3.9]
-
     steps:
     - uses: actions/checkout@v2
     - name: Build the testing stack


### PR DESCRIPTION
Contributes to #2 

Use _job name_ not _step name_ as the identification to wait for before publishing to docker hub