### PR TITLE
Test only one python version

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -19,9 +19,6 @@ jobs:
   test:
     name: Run test
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [3.9]
     steps:
     - uses: actions/checkout@v2
     - name: Build the testing stack
@@ -34,10 +31,10 @@ jobs:
         time: '5s'
     - name: Check running containers
       run: docker ps -a
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: 3.9
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
Contributes to #2 

Test job name was dynamically build because of the matrix version.

Use only python3.9 for tests. That should fix the name problem with the docker hub publish workflow.

Alternatively, we could use regexp to match the job name, but that is not important as we are not building a library but an application.